### PR TITLE
Built-in 'file()' was removed in Python in favor of 'open()'

### DIFF
--- a/pylane/shell/remote_shell.py
+++ b/pylane/shell/remote_shell.py
@@ -151,7 +151,7 @@ class RemoteShellThread(threading.Thread):
         else:
             ret = True, out
         if self.debug:
-            file('/tmp/pmx-shell-log', 'w').write("%s\n%s" % (
+            open('/tmp/pmx-shell-log', 'w').write("%s\n%s" % (
                 source, ret))
         return ret
 


### PR DESCRIPTION
__open()__ will work as expected in both Python 2 and Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/NtesEyes/pylane on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./pylane/shell/remote_shell.py:154:13: F821 undefined name 'file'
            file('/tmp/pmx-shell-log', 'w').write("%s\n%s" % (
            ^
1     F821 undefined name 'file'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree