### PR TITLE
fix: support for python >= 3.8

### DIFF
--- a/pylane/core/injector.py
+++ b/pylane/core/injector.py
@@ -6,6 +6,7 @@ import signal
 import time
 import tempfile
 import platform
+import re
 import subprocess
 import stat
 import atexit
@@ -65,8 +66,15 @@ class Injector(object):
         if 'BSD' in platform.platform():
             env['bsd'] = True
             self.run = self._bsd_run
-        if platform.dist()[0] == 'Ubuntu':
-            env['ubuntu'] = True
+
+        try:
+            with open('/etc/lsb-release', 'rb') as f:
+                lsb_release = f.read()
+            distrib = re.search(b'DISTRIB_ID=(.+)', lsb_release, re.MULTILINE).groups()[0]
+            if distrib == b'Ubuntu':
+                env['ubuntu'] = True
+        except Exception:
+            pass
 
         # check gdb
         if not os.access(self.gdb, os.X_OK):

--- a/pylane/shell/ipython_embed.py
+++ b/pylane/shell/ipython_embed.py
@@ -129,7 +129,7 @@ class IPythonShell(InteractiveShellEmbed):
             exit(0)
         flag, op = raw[0], raw[1:]
         # TODO old interface which is not used, going to be deprecated.
-        flag is '0'
+        flag == '0'
         return op
 
     def remote_completer(self, ipcompleter, text, line=None, cursor_pos=None):

--- a/pylane/shell/ipython_embed.py
+++ b/pylane/shell/ipython_embed.py
@@ -78,7 +78,7 @@ class IPythonShell(InteractiveShellEmbed):
                 self, raw_cell, store_history, silent, shell_futures
             )
 
-        result = ExecutionResult()
+        result = ExecutionResult(None)
         self.displayhook.exec_result = result
 
         if (not raw_cell) or raw_cell.isspace():

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,8 @@ setup(
         # 'build_py': build_py
     # },
     install_requires=[
-        "ipython==5.7",
-        # 'ipython==5.8;python_version<"3.4"',
-        # 'ipython==7.2;python_version>="3.4"',
+        'ipython==5.8;python_version<"3.4"',
+        'ipython>=7.2;python_version>="3.4"',
         "Click==7.0",
     ],
     keywords=['debug', 'attach', 'gdb', 'shell']

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 from os import path
 
 
-VERSION = '0.0.9'
+VERSION = '0.0.10'
 
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md')) as f:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 from os import path
 
 
-VERSION = '0.0.10'
+VERSION = '0.0.11'
 
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md')) as f:
@@ -35,7 +35,7 @@ setup(
     # },
     install_requires=[
         'ipython==5.8;python_version<"3.4"',
-        'ipython>=7.2;python_version>="3.4"',
+        'ipython>=7.2,<8.0;python_version>="3.4"',
         "Click==7.0",
     ],
     keywords=['debug', 'attach', 'gdb', 'shell']


### PR DESCRIPTION
platform.dist was removed in python 3.8, parse /etc/lsb-release instead